### PR TITLE
Fix: Replace references to images to actually be good on prod

### DIFF
--- a/docs/_writeups/01-KernelPanics/index.md
+++ b/docs/_writeups/01-KernelPanics/index.md
@@ -6,7 +6,7 @@ has_children: true
 ---
 
 <p align="center">
-  <img width="100%" src="../../assets/logo.png">
+  <img width="100%" src="/assets/logo.png">
 </p>
 
 "Why the FUCK doesn't my shit work dude? What the fuck is this? Some bullshit fucking shit fuck or something? You fucking suck as a fucking person and deserve to fucking die you fucking fascist!"

--- a/docs/_writeups/01-KernelPanics/index/02-XML.md
+++ b/docs/_writeups/01-KernelPanics/index/02-XML.md
@@ -8,7 +8,7 @@ nav_order: 1
 # "AppleIntelCPUPowerManagement" Kernel Panic
 
 <p align="center">
-  <img width="100%" src="../../../assets/VBoxKernelPanic1.png">
+  <img width="100%" src="/assets/VBoxKernelPanic1.png">
 </p>
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,4 +55,4 @@ permalink: /
 
 <h3 class="center">A very simple guide for running Mac OS X on VirtualBox.</h3>
 <h5 class="center">If you run into any issues, you can shoot me a message @ koltontheshek on Discord. </h5>
-<a href="/docs/docs/01-WelcomeArea/01-About">Get Started</a>
+<a href="/docs/01-WelcomeArea/01-About">Get Started</a>


### PR DESCRIPTION
This replaces ``../..`` references with `/` for production web